### PR TITLE
Sys hotswap

### DIFF
--- a/src/rawdata-downloader/src/system-tools/usr/sbin/rawdata-download
+++ b/src/rawdata-downloader/src/system-tools/usr/sbin/rawdata-download
@@ -213,8 +213,8 @@ check_module_address() {
 remove_scsi_device() {
   if [ -n "$HOTSWAP_USING_SYS" ] ; then
     log ${LINENO} set device $DEVICE  offline and delete it
-    echo offline | tee /sys/block/$DEVICE/device/state 2>&1 | logstdout ${LINENO}
-    echo 1 | tee /sys/block/$DEVICE/device/delete 2>&1 | logstdout ${LINENO}
+    echo offline | tee /sys/block/$(basename $DEVICE)/device/state 2>&1 | logstdout ${LINENO}
+    echo 1 | tee /sys/block/$(basename $DEVICE)/device/delete 2>&1 | logstdout ${LINENO}
   else 
     log ${LINENO} removing device mux $MUX_INDEX index $REMOTE_SSD_INDEX
     echo "scsi remove-single-device $SCSIHOST" | tee /proc/scsi/scsi 2>&1 | logstdout ${LINENO}


### PR DESCRIPTION
- by default, rawdata-download use /sys for hot-swapping instead of proc
- after requesting the multiplexer to connect another ssd, sleep 3 seconds before scanning the scsi host (when it is known, ie after the first SSD for subsequent SSDs, or when running rawdata-download again)
