### PR TITLE
FastCal

### DIFF
--- a/src/rawdata-movsplit/src/rawdata-movsplit
+++ b/src/rawdata-movsplit/src/rawdata-movsplit
@@ -523,7 +523,7 @@ def GetCameraModules(FastCalKeyFilePath):
     config.readfp(StringIO('[calibration]\n' + open(FastCalKeyFilePath, 'r').read()))
 
     # Return value
-    return config.getint('calibration', 'channels')
+    return config.getint('calibration', 'modules')
 
 # Function to merge threads results
 @timed


### PR DESCRIPTION
Use FastCal calibration file to get camera modules instead of XML
